### PR TITLE
fix: remove duplicate 'found in' and 'fixed in' prefixes

### DIFF
--- a/internal/govulncheck/vulnerability.go
+++ b/internal/govulncheck/vulnerability.go
@@ -117,8 +117,8 @@ func PrintVulnerabilities(logger *log.Logger, vulns []*Vulnerability) {
 		logger.Printf("Vulnerability #%d: %s\n", i+1, vuln.ID)
 		logger.Printf("    %s\n", vuln.Summary)
 		logger.Printf("  More info: %s\n", vuln.MoreInfo)
-		logger.Printf("    Found in: %s\n", vuln.FoundIn)
-		logger.Printf("    Fixed in: %s\n", vuln.FixedIn)
+		logger.Printf("    %s\n", vuln.FoundIn)
+		logger.Printf("    %s\n", vuln.FixedIn)
 		logger.Println("    Example traces found:")
 		for idx, info := range removeDuplicates(vuln.Traces) {
 			logger.Printf("      #%d: %s", idx+1, info)

--- a/internal/govulncheck/vulnerability_test.go
+++ b/internal/govulncheck/vulnerability_test.go
@@ -199,8 +199,8 @@ func TestPrintVulnerabilities(t *testing.T) {
 			ID:       "GO-2025-0001",
 			Summary:  "summary",
 			MoreInfo: "https://pkg.go.dev/vuln/GO-2025-0001",
-			FoundIn:  "pkg/pkg1@v1.0.0",
-			FixedIn:  "pkg/pkg1@v1.0.1",
+			FoundIn:  "Found in: pkg/pkg1@v1.0.0",
+			FixedIn:  "Fixed in: pkg/pkg1@v1.0.1",
 			Traces: []string{
 				"file1.go:10:2",
 				"file2.go:21:5",
@@ -211,8 +211,8 @@ func TestPrintVulnerabilities(t *testing.T) {
 			ID:       "GO-2025-0002",
 			Summary:  "summary",
 			MoreInfo: "https://pkg.go.dev/vuln/GO-2025-0002",
-			FoundIn:  "pkg/pkg2@v2.0.0",
-			FixedIn:  "pkg/pkg2@v2.0.1",
+			FoundIn:  "Found in: pkg/pkg2@v2.0.0",
+			FixedIn:  "Fixed in: pkg/pkg2@v2.0.1",
 			Traces: []string{
 				"file2.go:21:5",
 			},


### PR DESCRIPTION
before the fix, we may have reports such as:
```
2025/06/18 15:08:56 Vulnerability #2: GO-2024-2466
2025/06/18 15:08:56     Denial of service in github.com/go-git/go-git/v5 and gopkg.in/src-d/go-git.v4
2025/06/18 15:08:56   More info: https://pkg.go.dev/vuln/GO-2024-2466
2025/06/18 15:08:56     Found in: Found in: gopkg.in/src-d/go-git.v4@v4.13.1
2025/06/18 15:08:56     Fixed in: Fixed in: N/A
2025/06/18 15:08:56     Example traces found:
2025/06/18 15:08:56       #1: controllers/pod/analyzer/filesystem.go:74:24
2025/06/18 15:08:56       #2: controllers/pod/analyzer/filesystem_check.go:19:2
2025/06/18 15:08:56       #3: test/cri/client.go:77:32
2025/06/18 15:08:56       #4: pkg/rules/rules.go:165:55
2025/06/18 15:08:56       #5: main.go:196:37
2025/06/18 15:08:56       #6: pkg/configuration/config.go:104:26
2025/06/18 15:08:56       #7: main.go:130:17
2025/06/18 15:08:56       #8: testsupport/alerts/alerts.go:22:2
```

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
